### PR TITLE
GtkHeaderBar: Better icon for fallback app menu

### DIFF
--- a/gtk/gtkheaderbar.c
+++ b/gtk/gtkheaderbar.c
@@ -379,7 +379,7 @@ _gtk_header_bar_update_window_buttons (GtkHeaderBar *bar)
                     atk_object_set_name (accessible, _("Application menu"));
                   priv->titlebar_icon = image;
                   if (!_gtk_header_bar_update_window_icon (bar, window))
-                    gtk_image_set_from_icon_name (GTK_IMAGE (priv->titlebar_icon), "process-stop-symbolic", GTK_ICON_SIZE_MENU);
+                    gtk_image_set_from_icon_name (GTK_IMAGE (priv->titlebar_icon), "open-menu-symbolic", GTK_ICON_SIZE_MENU);
                   priv->shows_app_menu = TRUE;
                 }
               else if (strcmp (t[j], "minimize") == 0 &&


### PR DESCRIPTION
`process-stop-symbolic` causes [user](https://bugs.launchpad.net/elementaryos/+bug/1300022) [confusion](https://github.com/elementary/icons/issues/222) as to why a "stop" icon is being used for a menu. `open-menu-symbolic` is a more semantically-correct option and should be more compatible with more icon themes.